### PR TITLE
adds two critical pull requests from contributors:

### DIFF
--- a/js/__test__/mainTest.js
+++ b/js/__test__/mainTest.js
@@ -94,6 +94,15 @@ describe('draftToHtml test suite', () => {
     contentState = ContentState.createFromBlockArray(arrContentBlocks);
     result = draftToHtml(convertToRaw(contentState));
     assert.equal(output, result);
+
+    html = '<ol><li>1</li>\n<ol><li>2</li>\n<ol><li>3</li>\n</ol>'
+      + '\n</ol>\n<li>3</li>\n</ol>\n';
+    output = '<ol>\n<li>1</li>\n<ol>\n<li>2</li>\n<ol>\n<li>3'
+      + '</li>\n</ol>\n</ol>\n<li>3</li>\n</ol>\n';
+    arrContentBlocks = convertFromHTML(html);
+    contentState = ContentState.createFromBlockArray(arrContentBlocks);
+    result = draftToHtml(convertToRaw(contentState), undefined, false, () => {});
+    assert.equal(output, result);
   });
 
   it('should return correct result for different heading styles', () => {
@@ -110,6 +119,12 @@ describe('draftToHtml test suite', () => {
     assert.equal(html, result);
 
     html = '<blockquote>testing</blockquote>\n';
+    arrContentBlocks = convertFromHTML(html);
+    contentState = ContentState.createFromBlockArray(arrContentBlocks);
+    result = draftToHtml(convertToRaw(contentState));
+    assert.equal(html, result);
+
+    html = '<pre>testing</pre>\n';
     arrContentBlocks = convertFromHTML(html);
     contentState = ContentState.createFromBlockArray(arrContentBlocks);
     result = draftToHtml(convertToRaw(contentState));

--- a/js/block.js
+++ b/js/block.js
@@ -14,7 +14,7 @@ const blockTypesMapping = {
   'unordered-list-item': 'ul',
   'ordered-list-item': 'ol',
   blockquote: 'blockquote',
-  code: 'pre',
+  'code-block': 'pre',
 };
 
 /**

--- a/js/index.js
+++ b/js/index.js
@@ -22,7 +22,7 @@ export default function draftToHtml(
           listBlocks.push(block);
         } else {
           if (listBlocks.length > 0) {
-            const listHtml = getListMarkup(listBlocks, entityMap, hashtagConfig, customEntityTransform); // eslint-disable-line max-len
+            const listHtml = getListMarkup(listBlocks, entityMap, hashtagConfig, directional, customEntityTransform); // eslint-disable-line max-len
             html.push(listHtml);
             listBlocks = [];
           }


### PR DESCRIPTION
- ef5d7fca97ac105e5e0e443526dba234e444f4e9 Use 'code-block' rather than 'code' for <pre> tags (fixes #49)
- 53581dbe34fbede434b92acaea3ab441afde0529 Fixed a bug with not passing a directional parameter to getListMarkup function