### PR TITLE
Use 'code-block' rather than 'code' for <pre> tags (fixes #49)

### DIFF
--- a/js/__test__/mainTest.js
+++ b/js/__test__/mainTest.js
@@ -114,6 +114,12 @@ describe('draftToHtml test suite', () => {
     contentState = ContentState.createFromBlockArray(arrContentBlocks);
     result = draftToHtml(convertToRaw(contentState));
     assert.equal(html, result);
+
+    html = '<pre>testing</pre>\n';
+    arrContentBlocks = convertFromHTML(html);
+    contentState = ContentState.createFromBlockArray(arrContentBlocks);
+    result = draftToHtml(convertToRaw(contentState));
+    assert.equal(html, result);
   });
 
   it('should return correct result when there are emojis', () => {

--- a/js/block.js
+++ b/js/block.js
@@ -14,7 +14,7 @@ const blockTypesMapping = {
   'unordered-list-item': 'ul',
   'ordered-list-item': 'ol',
   blockquote: 'blockquote',
-  code: 'pre',
+  'code-block': 'pre',
 };
 
 /**

--- a/lib/draftjs-to-html.js
+++ b/lib/draftjs-to-html.js
@@ -44,7 +44,7 @@
     'unordered-list-item': 'ul',
     'ordered-list-item': 'ol',
     blockquote: 'blockquote',
-    code: 'pre'
+    'code-block': 'pre'
   };
   /**
   * Function will return HTML tag for a block.


### PR DESCRIPTION
此 PR 為修正以下 issue，因為原作者 repo: jpuri/draftjs-to-html 沒有在更新維護

- https://github.com/jpuri/draftjs-to-html/pull/76